### PR TITLE
fix `visit_create` not found error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv
 *.pyo 
 dist/*
 .nox
+.vscode

--- a/README.md
+++ b/README.md
@@ -72,3 +72,12 @@ The integration tests are available via `nox` but are skipped by default because
 run them with `nox -s integration`. The integration tests stand up a docker container using docker compose, 
 and manage two databases in that container. 
 
+### Integration tests
+
+The integration tests live in `tests/integration` - they stand up a docker container to serve postgres from,
+create two databases within the postgres instance, and create a `pglogical` subscription between them. 
+Run the integration tests with `nox -s integration`
+
+Some of the integration tests run alembic directly. These test should remain ordered top to bottom so
+failures make more sense. To add a new revision, change directories to `tests/integration`, then run 
+`alembic revision -m "some helpful descriptor"`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,7 @@ def integration(session, sqlalchemy):
     session.install("psycopg2-binary")
     session.install(".")
     session.install(f"sqlalchemy=={sqlalchemy}")
+    session.install("alembic")
     session.install("pytest")
 
     for _ in range(30):

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,27 +19,36 @@ def unit(session, sqlalchemy):
 @nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("sqlalchemy", ["1.4", "2.0"])
 def integration(session, sqlalchemy):
-    session.run("docker", "compose", "down", external=True)
-    session.run("docker", "compose", "rm", "-f", external=True)
-    session.run("docker", "compose", "up", "--build", "-d", external=True)
+    quiet = False
+    if session.posargs and "quiet" in session.posargs:
+        quiet = True
+    session.run("docker", "compose", "down", "-v", external=True, silent=quiet)
+    session.run("docker", "compose", "up", "--build", "-d", external=True, silent=quiet)
 
-    session.install("psycopg2-binary")
-    session.install(".")
-    session.install(f"sqlalchemy=={sqlalchemy}")
-    session.install("alembic")
-    session.install("pytest")
+    session.install("psycopg2-binary", silent=quiet)
+    session.install(".", silent=quiet)
+    session.install(f"sqlalchemy=={sqlalchemy}", silent=quiet)
+    session.install("alembic", silent=quiet)
+    session.install("pytest", silent=quiet)
+    session.install("flaky", silent=quiet)
 
     for _ in range(30):
         try:
             session.run(
-                "docker", "compose", "exec", "primary", "pg_isready", external=True
+                "docker",
+                "compose",
+                "exec",
+                "primary",
+                "pg_isready",
+                external=True,
+                silent=quiet,
             )
         except:
             time.sleep(0.5)
         else:
             break
 
-    session.run("pytest", "tests/integration/")
+    session.run("pytest", "tests/integration/", silent=quiet)
 
 
 @nox.session

--- a/pg/postgresql.conf
+++ b/pg/postgresql.conf
@@ -231,6 +231,7 @@ wal_level = logical			# minimal, replica, or logical
 checkpoint_timeout = 30s
 #max_wal_size = 1GB
 min_wal_size = 35MB
+fsync = off
 #checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_flush_after = 0		# measured in pages, 0 disables
 #checkpoint_warning = 30s		# 0 disables

--- a/pg/postgresql.conf
+++ b/pg/postgresql.conf
@@ -228,9 +228,9 @@ wal_level = logical			# minimal, replica, or logical
 
 # - Checkpoints -
 
-#checkpoint_timeout = 5min		# range 30s-1d
+checkpoint_timeout = 30s
 #max_wal_size = 1GB
-#min_wal_size = 80MB
+min_wal_size = 35MB
 #checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_flush_after = 0		# measured in pages, 0 disables
 #checkpoint_warning = 30s		# 0 disables

--- a/sqlalchemy_pglogical/base.py
+++ b/sqlalchemy_pglogical/base.py
@@ -1,0 +1,8 @@
+def ddl_to_replicate_command(ddl: str) -> str:
+    """
+    Given a DDL command as a string, return a pglogical replicate command for that DDL
+    """
+    # TODO: allow specifying the replication sets
+    return f"""SELECT pglogical.replicate_ddl_command($sqlalchemypglogical$
+    {ddl}
+    $sqlalchemypglogical$)"""

--- a/sqlalchemy_pglogical/replicate_alembic.py
+++ b/sqlalchemy_pglogical/replicate_alembic.py
@@ -1,0 +1,58 @@
+from alembic.ddl import base
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.compiler import DDLCompiler
+
+from sqlalchemy_pglogical.base import ddl_to_replicate_command
+
+
+@compiles(base.RenameTable)
+def visit_rename_table(element: base.RenameTable, compiler: DDLCompiler, **kw) -> str:
+    return ddl_to_replicate_command(base.visit_rename_table(element, compiler, **kw))
+
+
+@compiles(base.AddColumn)
+def visit_add_column(element: base.AddColumn, compiler: DDLCompiler, **kw) -> str:
+    return ddl_to_replicate_command(base.visit_add_column(element, compiler, **kw))
+
+
+@compiles(base.DropColumn)
+def visit_drop_column(element: base.DropColumn, compiler: DDLCompiler, **kw) -> str:
+    return ddl_to_replicate_command(base.visit_drop_column(element, compiler, **kw))
+
+
+@compiles(base.ColumnNullable)
+def visit_column_nullable(
+    element: base.ColumnNullable, compiler: DDLCompiler, **kw
+) -> str:
+    return ddl_to_replicate_command(base.visit_column_nullable(element, compiler, **kw))
+
+
+@compiles(base.ColumnType)
+def visit_column_type(element: base.ColumnType, compiler: DDLCompiler, **kw) -> str:
+    return ddl_to_replicate_command(base.visit_column_type(element, compiler, **kw))
+
+
+@compiles(base.ColumnName)
+def visit_column_name(element: base.ColumnName, compiler: DDLCompiler, **kw) -> str:
+    return ddl_to_replicate_command(base.visit_column_name(element, compiler, **kw))
+
+
+@compiles(base.ColumnDefault)
+def visit_column_default(
+    element: base.ColumnDefault, compiler: DDLCompiler, **kw
+) -> str:
+    return ddl_to_replicate_command(base.visit_column_default(element, compiler, **kw))
+
+
+@compiles(base.ComputedColumnDefault)
+def visit_computed_column(
+    element: base.ComputedColumnDefault, compiler: DDLCompiler, **kw
+):
+    return ddl_to_replicate_command(base.visit_computed_column(element, compiler, **kw))
+
+
+@compiles(base.IdentityColumnDefault)
+def visit_identity_column(
+    element: base.IdentityColumnDefault, compiler: DDLCompiler, **kw
+):
+    return ddl_to_replicate_command(base.visit_identity_column(element, compiler, **kw))

--- a/sqlalchemy_pglogical/replicate_ddl.py
+++ b/sqlalchemy_pglogical/replicate_ddl.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql.ddl import DDLElement
+from sqlalchemy.sql.ddl import ClauseElement, DDLElement
 
 
 def all_subclasses(cls):
@@ -30,10 +30,19 @@ def make_func(ddl):
     )
 
 
+def is_replicable(ddl):
+    name: str = ddl.__name__
+    if not (
+        name.startswith("Create") or name.startswith("Drop") or name.startswith("Alter")
+    ):
+        return False
+    if not hasattr(ddl, "__visit_name__"):
+        return False
+    return True
+
+
 # get every DDLElement that can be extended the way we expect (the hueristic here is having a `__visit_name__`)
-replicable_ddls = [
-    ddl for ddl in all_subclasses(DDLElement) if hasattr(ddl, "__visit_name__")
-]
+replicable_ddls = [ddl for ddl in all_subclasses(DDLElement) if is_replicable(ddl)]
 
 for ddl in replicable_ddls:
     # make a function and decorate it

--- a/tests/integration/alembic.ini
+++ b/tests/integration/alembic.ini
@@ -1,0 +1,116 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python-dateutil library that can be
+# installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = postgresql://me:veryinsecure@localhost/primary
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.options = --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/tests/integration/alembic/README
+++ b/tests/integration/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/tests/integration/alembic/env.py
+++ b/tests/integration/alembic/env.py
@@ -1,0 +1,79 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        version_table_schema="public",
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table_schema="public",
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/tests/integration/alembic/script.py.mako
+++ b/tests/integration/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/tests/integration/alembic/versions/4b361a7c7bf3_add_column.py
+++ b/tests/integration/alembic/versions/4b361a7c7bf3_add_column.py
@@ -10,6 +10,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+from sqlalchemy_pglogical import replicate_alembic
+
 # revision identifiers, used by Alembic.
 revision: str = "4b361a7c7bf3"
 down_revision: Union[str, None] = "b67a71ccf11e"
@@ -19,7 +21,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.add_column(
-        "users",
+        "account",
         sa.Column("new_column", sa.String(), server_default=""),
         schema="public",
     )

--- a/tests/integration/alembic/versions/4b361a7c7bf3_add_column.py
+++ b/tests/integration/alembic/versions/4b361a7c7bf3_add_column.py
@@ -1,0 +1,29 @@
+"""add column - this replicates a real-world bug
+
+Revision ID: 4b361a7c7bf3
+Revises: b67a71ccf11e
+Create Date: 2023-09-27 12:37:43.934215
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4b361a7c7bf3"
+down_revision: Union[str, None] = "b67a71ccf11e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("new_column", sa.String(), server_default=""),
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users")

--- a/tests/integration/alembic/versions/b67a71ccf11e_initial_revision.py
+++ b/tests/integration/alembic/versions/b67a71ccf11e_initial_revision.py
@@ -1,0 +1,31 @@
+"""initial revision
+
+Revision ID: b67a71ccf11e
+Revises: 
+Create Date: 2023-09-27 12:07:53.989729
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b67a71ccf11e"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "account",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(50), nullable=False),
+        sa.Column("description", sa.Unicode(200)),
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("account")

--- a/tests/integration/alembic/versions/b67a71ccf11e_initial_revision.py
+++ b/tests/integration/alembic/versions/b67a71ccf11e_initial_revision.py
@@ -10,6 +10,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+from sqlalchemy_pglogical import replicate_alembic
+
 # revision identifiers, used by Alembic.
 revision: str = "b67a71ccf11e"
 down_revision: Union[str, None] = None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,108 @@
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import Column, Integer, String, create_engine, text
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+
+@contextmanager
+def transactionless_session(sessionmaker_):
+    # break out of our transaction. see https://stackoverflow.com/questions/57186725/can-i-execute-query-via-sqlalchemy-without-transaction
+    with sessionmaker_() as session:
+        session.connection().execute(text("COMMIT"))
+        yield session
+
+
+def create_database_with_node(db_name):
+    """
+    Create a database in an existing postgres instance, enable pglogical, and create a pglogical node
+    """
+    username = "me"
+    password = "veryinsecure"
+    hostname = "localhost"
+    dsn = f"host={hostname} port=5432 dbname={db_name} user={username} password={password}"
+    connection_string = f"postgresql://me:veryinsecure@localhost/{db_name}"
+
+    # connect with another db
+    mydb_engine = create_engine("postgresql://me:veryinsecure@localhost/mydb")
+    MyDBSession = sessionmaker(mydb_engine)
+
+    with transactionless_session(MyDBSession) as session:
+        session.execute(
+            text(
+                f"""
+        SELECT 
+            pg_terminate_backend(pid) 
+        FROM 
+            pg_stat_activity 
+        WHERE 
+            -- don't kill my own connection!
+            pid <> pg_backend_pid()
+            -- don't kill the connections to other databases
+            AND datname = '{db_name}'
+    """
+            )
+        )
+        session.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        session.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+    engine = create_engine(connection_string)
+    Session = sessionmaker(engine)
+
+    with transactionless_session(Session) as session:
+        session.execute(text("CREATE EXTENSION IF NOT EXISTS pglogical"))
+    with transactionless_session(Session) as session:
+        session.execute(
+            text(
+                f"""SELECT pglogical.create_node(
+                        node_name := '{db_name}_node',
+                        dsn := '{dsn}'
+                        )"""
+            )
+        )
+
+    return connection_string
+
+
+@pytest.fixture(scope="function")
+def clean_primary():
+    connection_string = create_database_with_node("primary")
+    engine = create_engine(connection_string)
+    Session = sessionmaker(engine)
+
+    with transactionless_session(Session) as session:
+        session.execute(
+            text(
+                f"SELECT pglogical.replication_set_add_all_tables('default', ARRAY['public'])"
+            )
+        )
+    yield connection_string
+
+    with transactionless_session(Session) as session:
+        session.execute(text(f"SELECT pglogical.drop_node('primary_node')"))
+
+
+@pytest.fixture(scope="function")
+def clean_secondary():
+    connection_string = create_database_with_node("secondary")
+
+    engine = create_engine(connection_string)
+    Session = sessionmaker(engine)
+
+    with transactionless_session(Session) as session:
+        session.execute(
+            text(
+                """SELECT pglogical.create_subscription(
+        subscription_name := 'secondary_node',
+        provider_dsn := 'host=localhost port=5432 dbname=primary user=me password=veryinsecure'
+        );"""
+            )
+        )
+    yield connection_string
+    with transactionless_session(Session) as session:
+        session.execute(
+            text(
+                "SELECT pglogical.drop_subscription(subscription_name := 'secondary_node')"
+            )
+        )
+        session.execute(text("SELECT pglogical.drop_node('secondary_node')"))

--- a/tests/integration/test_alembic_migrations.py
+++ b/tests/integration/test_alembic_migrations.py
@@ -1,0 +1,80 @@
+import pathlib
+import time
+
+from alembic import command
+from alembic.config import Config
+from flaky import flaky
+from sqlalchemy import Column, Integer, String, create_engine, text
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+wait_lsn = text("select pglogical.wait_slot_confirm_lsn(NULL, NULL)")
+
+
+@flaky(max_runs=5, min_passes=2)
+def test_create_with_alembic(clean_primary, clean_secondary):
+    primary_engine = create_engine(clean_primary)
+    PrimarySession = sessionmaker(primary_engine)
+    logical_engine = create_engine(clean_secondary)
+    LogicalSession = sessionmaker(logical_engine)
+    config = Config(pathlib.Path(__file__).parent / "alembic.ini")
+    command.upgrade(config, "b67a71ccf11e")
+    # confirm the tables got made
+    table_query = text(
+        """
+    SELECT table_schema||'.'||table_name AS full_rel_name 
+    FROM information_schema.tables 
+    WHERE table_schema = 'public'"""
+    )
+
+    with PrimarySession() as primary_session:
+        primary_session.execute(wait_lsn)
+        primary_tables = primary_session.execute(table_query)
+        primary_table = primary_tables.first()
+    for _ in range(30):
+        # make the session inside the loop to make sure we're not holding any cursors, etc.
+        with LogicalSession() as logical_session:
+            logical_session.execute(wait_lsn)
+            logical_tables = logical_session.execute(table_query)
+            logical_table = logical_tables.first()
+            if logical_table is not None:
+                break
+            time.sleep(0.5)
+
+    assert primary_table is not None
+    assert logical_table is not None
+
+
+@flaky(max_runs=5, min_passes=2)
+def test_add_column_with_alembic(clean_primary, clean_secondary):
+    config = Config(pathlib.Path(__file__).parent / "alembic.ini")
+    command.upgrade(config, "4b361a7c7bf3")
+    primary_engine = create_engine(clean_primary)
+    PrimarySession = sessionmaker(primary_engine)
+    logical_engine = create_engine(clean_secondary)
+    LogicalSession = sessionmaker(logical_engine)
+
+    column_query = text(
+        """SELECT
+                    column_name
+                FROM
+                    information_schema.columns
+                WHERE
+                    table_name = 'account'
+                    and column_name = 'new_column';"""
+    )
+
+    with PrimarySession() as primary_session:
+        primary_session.execute(wait_lsn)
+        primary_columns = primary_session.execute(column_query)
+        primary_column = primary_columns.first()
+    for _ in range(30):
+        with LogicalSession() as logical_session:
+            logical_session.execute(wait_lsn)
+            logical_columns = logical_session.execute(column_query)
+            logical_column = logical_columns.first()
+            if logical_column is not None:
+                break
+            time.sleep(0.5)
+
+    assert primary_column is not None
+    assert logical_column is not None

--- a/tests/integration/test_create_tables.py
+++ b/tests/integration/test_create_tables.py
@@ -1,97 +1,7 @@
-import pathlib
 import time
-from contextlib import contextmanager
 
-import pytest
-from alembic import command
-from alembic.config import Config
-from alembic.context import EnvironmentContext
-from alembic.migration import MigrationContext
-from alembic.script import ScriptDirectory
 from sqlalchemy import Column, Integer, String, create_engine, text
 from sqlalchemy.orm import declarative_base, sessionmaker
-
-# from alembic.operations import Operations
-
-
-
-@contextmanager
-def transactionless_session(sessionmaker_):
-    # break out of our transaction. see https://stackoverflow.com/questions/57186725/can-i-execute-query-via-sqlalchemy-without-transaction
-    with sessionmaker_() as session:
-        session.connection().execute(text("COMMIT"))
-        yield session
-
-
-def create_database_with_node(db_name):
-    """
-    Create a database in an existing postgres instance, enable pglogical, and create a pglogical node
-    """
-    username = "me"
-    password = "veryinsecure"
-    hostname = "localhost"
-    dsn = f"host={hostname} port=5432 dbname={db_name} user={username} password={password}"
-    connection_string = f"postgresql://me:veryinsecure@localhost/{db_name}"
-
-    # connect with another db
-    mydb_engine = create_engine("postgresql://me:veryinsecure@localhost/mydb")
-    MyDBSession = sessionmaker(mydb_engine)
-
-    with transactionless_session(MyDBSession) as session:
-        session.execute(text(f'DROP DATABASE IF EXISTS "{db_name}" '))
-        session.execute(text(f'CREATE DATABASE "{db_name}"'))
-
-    engine = create_engine(connection_string)
-    Session = sessionmaker(engine)
-
-    with transactionless_session(Session) as session:
-        session.execute(text("CREATE EXTENSION IF NOT EXISTS pglogical"))
-    with transactionless_session(Session) as session:
-        session.execute(
-            text(
-                f"""SELECT pglogical.create_node(
-                        node_name := '{db_name}_node',
-                        dsn := '{dsn}'
-                        )"""
-            )
-        )
-
-    return connection_string
-
-
-@pytest.fixture(scope="session")
-def clean_primary():
-    connection_string = create_database_with_node("primary")
-    engine = create_engine(connection_string)
-    Session = sessionmaker(engine)
-
-    with transactionless_session(Session) as session:
-        session.execute(
-            text(
-                f"SELECT pglogical.replication_set_add_all_tables('default', ARRAY['public'])"
-            )
-        )
-    return connection_string
-
-
-@pytest.fixture(scope="session")
-def clean_secondary():
-    connection_string = create_database_with_node("secondary")
-
-    engine = create_engine(connection_string)
-    Session = sessionmaker(engine)
-
-    with transactionless_session(Session) as session:
-        session.execute(
-            text(
-                """SELECT pglogical.create_subscription(
-        subscription_name := 'secondary_node',
-        provider_dsn := 'host=localhost port=5432 dbname=primary user=me password=veryinsecure'
-        );"""
-            )
-        )
-    return connection_string
-
 
 Base = declarative_base()
 
@@ -143,14 +53,3 @@ def test_creates_tables(clean_primary, clean_secondary):
                 break
             time.sleep(0.5)
     assert table is not None
-
-
-def test_create_with_alembic(clean_primary, clean_secondary):
-    config = Config(pathlib.Path(__file__).parent / "alembic.ini")
-    command.upgrade(config, "b67a71ccf11e")
-
-
-def test_add_column_with_alembic(clean_primary, clean_secondary):
-    config = Config(pathlib.Path(__file__).parent / "alembic.ini")
-    command.upgrade(config, "b67a71ccf11e")
-    command.upgrade(config, "4b361a7c7bf3")

--- a/tests/integration/test_create_tables.py
+++ b/tests/integration/test_create_tables.py
@@ -1,9 +1,18 @@
+import pathlib
 import time
 from contextlib import contextmanager
 
 import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.context import EnvironmentContext
+from alembic.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from sqlalchemy import Column, Integer, String, create_engine, text
 from sqlalchemy.orm import declarative_base, sessionmaker
+
+# from alembic.operations import Operations
+
 
 
 @contextmanager
@@ -134,3 +143,14 @@ def test_creates_tables(clean_primary, clean_secondary):
                 break
             time.sleep(0.5)
     assert table is not None
+
+
+def test_create_with_alembic(clean_primary, clean_secondary):
+    config = Config(pathlib.Path(__file__).parent / "alembic.ini")
+    command.upgrade(config, "b67a71ccf11e")
+
+
+def test_add_column_with_alembic(clean_primary, clean_secondary):
+    config = Config(pathlib.Path(__file__).parent / "alembic.ini")
+    command.upgrade(config, "b67a71ccf11e")
+    command.upgrade(config, "4b361a7c7bf3")


### PR DESCRIPTION
This adds an alembic environment to the integration tests, so we could reproduce and fix the error `AttributeError: 'PGDDLCompiler' object has no attribute 'visit_clause'`